### PR TITLE
Add helper for hash input preparation

### DIFF
--- a/ciphersuite-shared/src/__test__/hash-input.test.ts
+++ b/ciphersuite-shared/src/__test__/hash-input.test.ts
@@ -1,0 +1,60 @@
+import { latin1ToBytes } from '..'
+import { HashInput, IETF_SPAKE2_HI_CFG, IETF_VOPRF_HI_CFG } from '../hash-input'
+
+describe('Test HashInput helper', () => {
+    const OPRF_SPEC_ID = Uint8Array.from([86, 79, 80, 82, 70, 48, 55, 45]) // "VOPRF07-"
+
+    test('IETF-VOPRF hash input', () => {
+        const hi = new HashInput(OPRF_SPEC_ID, IETF_VOPRF_HI_CFG)
+        hi.update(Uint8Array.from([1]))
+            .update(Uint8Array.from([2, 2]))
+            .update(Uint8Array.from([3, 3, 3]))
+            .update('VOPRF')
+
+        const expected = Uint8Array.from([
+            86, 79, 80, 82, 70, 48, 55, 45, 0, 1, 1, 0, 2, 2, 2, 0, 3, 3, 3, 3, 0, 5, 86, 79, 80, 82, 70,
+        ])
+        expect(hi.data).toEqual(expected)
+    })
+    test('IETF-SPAKE2 hash input', () => {
+        const hi = new HashInput(latin1ToBytes('SPAKE2+ draft-01'), IETF_SPAKE2_HI_CFG)
+        hi.update(Uint8Array.from([1]))
+            .update(Uint8Array.from([2, 2]))
+            .update(Uint8Array.from([3, 3, 3]))
+
+        const expected = Uint8Array.from([
+            ...latin1ToBytes('SPAKE2+ draft-01'),
+            1,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            2,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            2,
+            3,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3,
+            3,
+            3,
+        ])
+        expect(hi.data).toEqual(expected)
+    })
+})

--- a/ciphersuite-shared/src/hash-input.ts
+++ b/ciphersuite-shared/src/hash-input.ts
@@ -1,0 +1,47 @@
+import { I2OSP, latin1ToBytes } from '.'
+
+export interface HashInputConfig {
+    byteOrder: 'BE' | 'LE'
+    lengthPrefixSizeBytes: number
+}
+
+export const IETF_VOPRF_HI_CFG: HashInputConfig = {
+    byteOrder: 'BE',
+    lengthPrefixSizeBytes: 2,
+}
+
+export const IETF_SPAKE2_HI_CFG: HashInputConfig = {
+    byteOrder: 'LE',
+    lengthPrefixSizeBytes: 8,
+}
+
+export class HashInput {
+    private _buf: number[] = []
+    // If the prefix is a string it MUST be latin1 encoded
+    // The VOPRF spec uses 2-byte length prefixes. SPAKE2+ uses 8-byte prefixes
+    constructor(prefix: Uint8Array | string, private _config: HashInputConfig) {
+        this._buf = [...ensureUint8Array(prefix)]
+    }
+
+    update(data: Uint8Array | string): HashInput {
+        const uint8Data = ensureUint8Array(data)
+        this._buf = [
+            ...this._buf,
+            ...xEndianI2OSP(uint8Data.length, this._config.lengthPrefixSizeBytes, this._config.byteOrder),
+            ...uint8Data,
+        ]
+        return this
+    }
+
+    get data(): Uint8Array {
+        return Uint8Array.from(this._buf)
+    }
+}
+
+function xEndianI2OSP(n: number, len: number, byteOrder: 'BE' | 'LE'): Uint8Array {
+    return byteOrder === 'BE' ? I2OSP(n, len) : I2OSP(n, len).reverse()
+}
+
+function ensureUint8Array(arg: Uint8Array | string): Uint8Array {
+    return typeof arg === 'string' ? latin1ToBytes(arg) : arg
+}


### PR DESCRIPTION
Many protocols require byte arrays added to hash inputs to be prefixed by their length. Protocols differ, however, on the size of this prefix in bytes and the endianness of the number.

This PR adds a helper class that takes a protocol specific configuration specifiying prefix length and endianness, and builds the hash input array with a fluent interface.